### PR TITLE
Fix problem where chop was always chopping everything

### DIFF
--- a/src/Command/ChopCommand.php
+++ b/src/Command/ChopCommand.php
@@ -87,7 +87,7 @@ class ChopCommand extends Command
         $config = (new Config())->parse($input->getOption('config'));
         $group = $input->getOption('group') ?: $config->get(Config::CONFIG_DEFAULT_GROUP);
 
-        $tablePopulator = $input->getOption(static::OPTION_CONFIG)
+        $tablePopulator = $input->getOption(static::OPTION_ALL)
             ? new DbTablePopulator()
             : new FileTablePopulator(new Local('/'));
         $schemaParser = new SchemaParser($tablePopulator, $config, $group);


### PR DESCRIPTION
`chop` is meant to only chop tables for which seed data exists unless you explicitly tell it to chop all. This was not working correctly and chopping everything by default. This PR fixes that.