### PR TITLE
SE2-752/add caching_sha2_password support for MySQL 8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,12 @@ COPY composer.lock /app/composer.lock
 
 RUN composer install --no-ansi --no-dev --no-interaction --no-suggest --no-progress --no-scripts --optimize-autoloader --prefer-dist
 
-FROM graze/php-alpine:7.3 AS run
+FROM graze/php-alpine:7.4 AS run
 
 RUN set +xe \
     && apk add --no-cache \
-        mariadb-client
+        mariadb-client \
+        mariadb-connector-c
 
 WORKDIR /app
 COPY --from=build-php /app/src /app/src


### PR DESCRIPTION
## Summary

- Bump runtime base from `graze/php-alpine:7.3` to `graze/php-alpine:7.4` — `mysqlnd` in 7.4 has `auth_plugin_caching_sha2_password` built in, unlike the Alpine 3.9 / PHP 7.3 build.
- Add `mariadb-connector-c` so the `mysql` CLI can load `caching_sha2_password.so`.
- Composer platform constraint stays at 7.3 (`composer.json` unchanged); vendor code runs unmodified on 7.4.

## Why now

MySQL 8.4 (being rolled out under SE2-752) removes `mysql_native_password` as a default plugin and mandates `caching_sha2_password`. The current `graze/sprout:latest` fails on both code paths when talking to 8.4:

- **PHP PDO/mysqli**: `SQLSTATE[HY000] [2054] The server requested authentication method unknown to the client` — mysqlnd in the old base lacks the plugin.
- **Shell-outs to `mysql` CLI** (used by `sprout chop`/`seed`): `ERROR 1045 (28000): Plugin caching_sha2_password could not be loaded` — plugin file not shipped.

Both are fixed by this PR.

## Test plan

- [x] `make build && make build-docker` succeeds.
- [x] `php -r phpinfo()` in the built image shows `auth_plugin_caching_sha2_password` in mysqlnd plugins.
- [x] `/usr/lib/mariadb/plugin/caching_sha2_password.so` is present.
- [x] PDO connect against a MySQL 8.4 server using `caching_sha2_password` succeeds.
- [x] `mysql` CLI connect against the same server succeeds.
- [x] End-to-end: `make db-data-web` / `db-data-dispatch` in the `web` repo (which invokes `sprout chop` + `seed` against mysql:8.4) completes with exit 0 and zero auth errors.
- [ ] Verify existing integ/staging/uat sprout configs still parse (no config-shape changes in this PR, but re-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)