### PR TITLE
fix/drop -it from docs-build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ docs-test: ## Run docs test server
 	docker run --rm -it -p 8000:8000 -v $$(pwd):/docs squidfunk/mkdocs-material
 
 docs-build: ## Build the mkdocs documentation
-	docker run --rm -it -v $$(pwd):/docs squidfunk/mkdocs-material build
+	docker run --rm -v $$(pwd):/docs squidfunk/mkdocs-material build
 
 docs-deploy: ## Deploy the mkdocs documentation
 	docker run --rm -it -v ~/.ssh:/root/.ssh -v $$(pwd):/docs -e GITHUB_TOKEN squidfunk/mkdocs-material gh-deploy


### PR DESCRIPTION
## Summary

The new GitHub Actions docs deploy workflow (added in #16) calls \`make docs-build\`, which fails on every push to \`main\` with:

\`\`\`
the input device is not a TTY
make: *** [Makefile:91: docs-build] Error 1
\`\`\`

See https://github.com/graze/sprout/actions/runs/25489756405/job/74794449988 for the failure.

## Root cause

\`docs-build\` runs:

\`\`\`
docker run --rm -it -v \$\$(pwd):/docs squidfunk/mkdocs-material build
\`\`\`

\`-it\` requires a TTY. Travis happened to allocate one, so the target worked there. GitHub Actions runners don't, so docker exits non-zero before mkdocs ever starts.

\`mkdocs build\` is non-interactive and has no use for stdin or a tty, so the flags are just dead weight.

## Notable changes

- \`Makefile\` \`docs-build\` target: drop \`-it\` from the docker invocation.

\`docs-test\` and \`docs-deploy\` are intentionally untouched. \`docs-test\` is interactive on purpose; \`docs-deploy\` isn't called from CI (the workflow uses \`peaceiris/actions-gh-pages\` instead).

## QA

- Locally: \`make docs-build\` still produces a working \`./site\` directory.
- Once merged, the next push to \`main\` should run the docs deploy workflow successfully.