### PR TITLE
chore/drop EOL PHP 7.0 and 7.1 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4']
         prefer_lowest: [false, true]
     steps:
       - uses: actions/checkout@v4
@@ -28,11 +28,7 @@ jobs:
         run: composer config platform.php "$(php -r 'echo PHP_VERSION;')"
 
       - name: Allow legacy deps with advisories (PHPUnit 5–7, symfony/process 2–4)
-        # audit.block-insecure was added in Composer 2.7. PHP 7.0/7.1 ship
-        # with Composer 2.2 (last minor that supports those PHP versions),
-        # which rejects the unknown key — that's fine, 2.2 doesn't have
-        # block-insecure to worry about anyway.
-        run: composer config audit.block-insecure false || true
+        run: composer config audit.block-insecure false
 
       - name: Install dependencies
         run: composer update --no-ansi --no-interaction --no-progress --no-scripts --prefer-dist ${{ matrix.prefer_lowest && '--prefer-lowest' || '' }}


### PR DESCRIPTION
## Summary

Narrow the CI matrix to PHP 7.2-7.4. Drops 7.0 and 7.1 (EOL since 2018 and 2019). Also drops the now-redundant Composer 2.2 workaround on the audit.block-insecure step.

The immediate trigger is Dependabot PR #14 (phpunit 7.3.1 -> 8.5.52), which fails CI on the 7.0 and 7.1 rows because phpunit 8 requires PHP >= 7.2. Trimming the matrix lets that PR (and any future bumps with similar floors) proceed against the PHP versions we actually still support.

## Notable changes

- ``.github/workflows/ci.yml``:
  - ``matrix.php`` from ``['7.0', '7.1', '7.2', '7.3', '7.4']`` to ``['7.2', '7.3', '7.4']``.
  - Drop the ``|| true`` workaround and explanatory comment on the ``composer config audit.block-insecure false`` step. PHP 7.2+ ship with Composer >= 2.7 via setup-php, which understands the key, so the soft-fail is no longer needed.

``composer.json`` still says ``"php": "^7.0"``. Widening that constraint changes semver and is a separate call — leaving it alone keeps the package install metadata honest about what packagist still claims is supported, while CI focuses on what we actually exercise.

## QA

- Inspect PR CI: 6 jobs (3 PHP versions x prefer_lowest yes/no) + 1 Markdown.
- After merge, re-run dependabot/composer/phpunit/phpunit-8.5.52 on PR #14 and confirm all 6 PHP jobs go green.