### PR TITLE
chore/add : void return type to test setUp() overrides

### DIFF
--- a/tests/unit/Db/DbTablePopulatorTest.php
+++ b/tests/unit/Db/DbTablePopulatorTest.php
@@ -36,7 +36,7 @@ class DbTablePopulatorTest extends TestCase
     /** @var mixed */
     private $pdoFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->pdoFactory = Mockery::mock(PdoFactory::class);
         $this->tableFilterer = Mockery::mock(TableFilterer::class);

--- a/tests/unit/Dump/DumperTest.php
+++ b/tests/unit/Dump/DumperTest.php
@@ -37,7 +37,7 @@ class DumperTest extends TestCase
     /** @var mixed */
     private $filesystem;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->config = Mockery::mock(SchemaConfigInterface::class);
         $this->outputter = Mockery::mock(OutputInterface::class);

--- a/tests/unit/Parser/FileTablePopulatorTest.php
+++ b/tests/unit/Parser/FileTablePopulatorTest.php
@@ -31,7 +31,7 @@ class FileTablePopulatorTest extends TestCase
     /** @var mixed */
     private $tableFilterer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fileSystem = Mockery::mock(AdapterInterface::class);
         $this->tableFilterer = Mockery::mock(TableFilterer::class);

--- a/tests/unit/Parser/SchemaParserTest.php
+++ b/tests/unit/Parser/SchemaParserTest.php
@@ -30,7 +30,7 @@ class SchemaParserTest extends TestCase
     /** @var SchemaParser */
     private $schemaParser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tablePopulator = Mockery::mock(FileTablePopulator::class);
         $this->config = Mockery::mock(Config::class);


### PR DESCRIPTION
## Summary

PHPUnit 8 added \`: void\` return type declarations to \`TestCase::setUp()\`, \`tearDown()\`, and the related lifecycle hooks. Existing overrides without \`: void\` are LSP-incompatible and fail with a fatal error under PHPUnit 8 (see https://github.com/graze/sprout/actions/runs/25490601510 for the failure on Dependabot PR #14).

This is a forward-compat tweak: \`: void\` is also valid under PHPUnit 5/6/7 (PHP 7+ allows a child method to add a return type when the parent declares none), so the change is safe against the currently-pinned \`phpunit ^5.7.21 | ^6 | ^7\` constraint and unblocks any future bump to ^8 or ^9.

## Notable changes

Added \`: void\` to the \`setUp()\` declarations in:

- \`tests/unit/Db/DbTablePopulatorTest.php\`
- \`tests/unit/Dump/DumperTest.php\`
- \`tests/unit/Parser/FileTablePopulatorTest.php\`
- \`tests/unit/Parser/SchemaParserTest.php\`

The suite has no \`tearDown()\`, \`setUpBeforeClass()\`, \`tearDownAfterClass()\`, \`assertPreConditions()\`, \`assertPostConditions()\`, or \`onNotSuccessfulTest()\` overrides — checked with grep.

## QA

- CI on this branch should still go green against PHPUnit 7.x (the currently resolved version).
- After this lands, Dependabot's PR #14 (phpunit 7 -> 8) should also pass; if Dependabot does not auto-rerun, click \"Update branch\" or comment \`@dependabot rebase\` on #14.