### PR TITLE
chore/bump mockery floor to ^1.3 for PHPUnit 8 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
   },
   "require-dev": {
     "graze/standards": "^2.0",
-    "mockery/mockery": "^1",
+    "mockery/mockery": "^1.3",
     "phpunit/phpunit": "^5.7.21 | ^6 | ^7",
     "squizlabs/php_codesniffer": "^3.3.1"
   },


### PR DESCRIPTION
## Summary

Bump the \`mockery/mockery\` floor from \`^1\` to \`^1.3\` so \`--prefer-lowest\` resolves a phpunit-8-compatible mockery.

## Root cause

Mockery added \`: void\` return-type overrides on its \`MockeryPHPUnitIntegration\` trait in **1.3.0** (2019), to match the return-type changes in PHPUnit 8. The current \`^1\` floor lets \`--prefer-lowest\` resolve mockery 1.0.x, which still has the return-typeless overrides and fatals when paired with PHPUnit 8:

\`\`\`
PHP Fatal error: Declaration of Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration::assertPostConditions()
must be compatible with PHPUnit\Framework\TestCase::assertPostConditions(): void
\`\`\`

Observed on the \`(lowest)\` rows of Dependabot PR #14's CI run after PR #19 landed the test-side \`: void\` fix on main: https://github.com/graze/sprout/actions/runs/25491075651

## Notable changes

- \`composer.json\`: \`"mockery/mockery": "^1"\` -> \`"mockery/mockery": "^1.3"\`.

Mockery ^1.3 supports PHP 5.6+ and PHPUnit 5.x/6.x/7.x/8.x, so this is non-breaking against the suite's currently-pinned \`phpunit ^5.7.21 | ^6 | ^7\` constraint. No code changes.

## QA

- CI on this PR: 6 jobs (PHP 7.2/7.3/7.4 x prefer_lowest yes/no) + Markdown should all stay green against phpunit 7.x + mockery 1.3.0.
- Once merged, Dependabot's PR #14 rebased onto main should pass all 6 PHP jobs.